### PR TITLE
added GetFileSize function

### DIFF
--- a/fileUtils/getFileSize.go
+++ b/fileUtils/getFileSize.go
@@ -1,0 +1,23 @@
+// Package fileUtils contains utility functions for working with files.
+package fileUtils
+
+import (
+	"os"
+	"log"
+)
+
+func GetFileSize(pathToFile string) int64 {
+	file, err := os.Stat(pathToFile);
+
+	//if file can't be found create an err message and close program
+	if os.IsNotExist(err) {	
+		log.Fatal("File does not exsist at: ", pathToFile)
+	}
+	//if any filesystem error occurs close the program with err details
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// get and return the size of the file
+	return file.Size()
+}


### PR DESCRIPTION
This fixes issue #3. The function returns an int64 number representing the number of bytes the file has. If the file is not found an error message is displayed. If any other filesystem errors cause it to fail the error details are displayed.

